### PR TITLE
added rudimentary profiling  capabilities for performance analysis

### DIFF
--- a/read_profile.py
+++ b/read_profile.py
@@ -1,0 +1,24 @@
+import sys, os
+import cProfile, pstats
+import argparse
+
+def init_parser():
+    parser = argparse.ArgumentParser(description='Vit small datasets quick training script')
+    parser.add_argument('--inpath', default=f'data', type=str)
+    parser.add_argument('--outpath', default=f'data', type=str)
+    return parser
+
+def analyze_dmp(myinfilepath='stats.dmp', myoutfilepath='stats.log'):
+    out_stream = open(myoutfilepath, 'w')
+    ps = pstats.Stats(myinfilepath, stream=out_stream)
+    sortby = 'cumulative'
+
+    ps.strip_dirs().sort_stats(sortby).print_stats(.3)  # plink around with this to get the results you need
+
+def main(args):   
+    analyze_dmp(myinfilepath=args.inpath, myoutfilepath=args.outpath)
+
+if __name__ == '__main__':
+    parser = init_parser()
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
added basic profiling with cprofile. Could be useful to see what methods take up how much time on the remote hosts for optimization purposes. Has to be toggeled on via new commandline parameter "--performance_profile". Profile is saved in a file in saved in the results folder of the run. Also added a small script to print these results into a human readable file when desired.

new imports shouldnt require an update of requirements.txt